### PR TITLE
Limit recent tracks list to three entries

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -786,7 +786,9 @@ export function App() {
         <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-4 text-sm shadow-lg shadow-slate-900/30">
           <div className="flex items-center justify-between gap-2">
             <p className="text-xs uppercase tracking-[0.3em] text-cyan-300/80">Последние треки</p>
-            <span className="text-[0.65rem] text-slate-500">Сессия хранит до {MAX_RECENT_TRACKS} записей</span>
+            <span className="text-[0.65rem] text-slate-500">
+              Запоминаем до {MAX_RECENT_TRACKS} последних загрузок за сессию
+            </span>
           </div>
           <div className="mt-3 space-y-2">
             {recentTracks.map((entry) => {

--- a/apps/web/src/audio/recentTracks.ts
+++ b/apps/web/src/audio/recentTracks.ts
@@ -10,7 +10,7 @@ export interface StoredRecentTrack {
 }
 
 export const RECENT_TRACKS_STORAGE_KEY = 'the-path:recent-tracks'
-export const MAX_RECENT_TRACKS = 6
+export const MAX_RECENT_TRACKS = 3
 
 const getStorage = (storage?: Storage): Storage | null => {
   if (storage) return storage
@@ -70,8 +70,11 @@ export const upsertRecentTrack = (
   entry: StoredRecentTrack,
   limit = MAX_RECENT_TRACKS,
 ): StoredRecentTrack[] => {
+  const safeLimit = Math.max(1, limit)
   const filtered = tracks.filter((track) => track.id !== entry.id)
-  return [entry, ...filtered].slice(0, Math.max(1, limit))
+  const deduped = [...filtered, entry]
+  deduped.sort((a, b) => b.createdAt - a.createdAt)
+  return deduped.slice(0, safeLimit)
 }
 
 export const toManifest = (entry: StoredRecentTrack): AudioTrackManifestEntry => ({


### PR DESCRIPTION
## Summary
- reduce the stored recent track history to three entries and sort by recency when upserting
- update the recent uploads helper copy to mention the three-item session limit

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d325dc4a808323bea0f9563c0fa8e3