### PR TITLE
fix: resolve ts build errors

### DIFF
--- a/apps/web/src/render/sceneRenderer.visual.test.ts
+++ b/apps/web/src/render/sceneRenderer.visual.test.ts
@@ -100,7 +100,7 @@ const createRecordingContext = () => {
     clearRect: (x: number, y: number, w: number, h: number) => record(`clearRect ${x} ${y} ${w} ${h}`),
     createLinearGradient: (...coords: number[]) => createGradient('linear', coords),
     createRadialGradient: (...coords: number[]) => createGradient('radial', coords),
-    createPattern: vi.fn(() => undefined),
+    createPattern: vi.fn(() => null),
     fillRect: (x: number, y: number, w: number, h: number) =>
       record(`fillRect ${x} ${y} ${w} ${h} style=${describeFill(fillStyleValue)}`),
     beginPath: () => record('beginPath'),
@@ -118,8 +118,25 @@ const createRecordingContext = () => {
       record(`roundRect ${x} ${y} ${w} ${h} ${r ?? 0}`),
     rect: (x: number, y: number, w: number, h: number) => record(`rect ${x} ${y} ${w} ${h}`),
     fillText: vi.fn(),
-    drawImage: (_image: CanvasImageSource, dx: number, dy: number, dw: number, dh: number) =>
-      record(`drawImage ${dx} ${dy} ${dw} ${dh}`),
+    drawImage: ((_image: CanvasImageSource, ...args: number[]) => {
+      let dx = 0
+      let dy = 0
+      let dw = 0
+      let dh = 0
+
+      if (args.length === 2) {
+        ;[dx, dy] = args
+      } else if (args.length === 4) {
+        ;[dx, dy, dw, dh] = args
+      } else if (args.length >= 6) {
+        dx = args[4] ?? 0
+        dy = args[5] ?? 0
+        dw = args[6] ?? 0
+        dh = args[7] ?? 0
+      }
+
+      record(`drawImage ${dx} ${dy} ${dw} ${dh}`)
+    }) as CanvasRenderingContext2D['drawImage'],
   }
 
   Object.defineProperty(context, 'fillStyle', {

--- a/apps/web/src/render/textures.ts
+++ b/apps/web/src/render/textures.ts
@@ -13,8 +13,10 @@ type TextureRecord = {
   promise?: Promise<HTMLImageElement>
 }
 
+type PatternRepetition = 'repeat' | 'repeat-x' | 'repeat-y' | 'no-repeat'
+
 type PatternOptions = {
-  repetition?: CanvasPatternRepetition
+  repetition?: PatternRepetition
 }
 
 const manifest = JSON.parse(manifestSource) as Record<string, TextureInfo>

--- a/apps/web/src/share/CanvasRecorder.test.ts
+++ b/apps/web/src/share/CanvasRecorder.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import CanvasRecorder, { type RecorderState } from './CanvasRecorder'
 
-type MutableGlobal = typeof globalThis & {
+type MutableGlobal = Omit<typeof globalThis, 'MediaRecorder' | 'MediaStream'> & {
   MediaRecorder?: typeof MediaRecorder
   MediaStream?: typeof MediaStream
 }
@@ -9,6 +9,8 @@ type MutableGlobal = typeof globalThis & {
 const mutableGlobal = globalThis as MutableGlobal
 const originalMediaRecorder = mutableGlobal.MediaRecorder
 const originalMediaStream = mutableGlobal.MediaStream
+const hadMediaRecorder = Object.prototype.hasOwnProperty.call(globalThis, 'MediaRecorder')
+const hadMediaStream = Object.prototype.hasOwnProperty.call(globalThis, 'MediaStream')
 
 class FakeMediaStream {
   private readonly tracks: MediaStreamTrack[]
@@ -82,23 +84,15 @@ describe('CanvasRecorder', () => {
   })
 
   afterEach(() => {
-    if (originalMediaStream) {
+    if (hadMediaStream) {
       mutableGlobal.MediaStream = originalMediaStream
     } else {
-
-      mutableGlobal.MediaStream = undefined
-
-      delete mutableGlobal.MediaStream
-
+      Reflect.deleteProperty(mutableGlobal, 'MediaStream')
     }
-    if (originalMediaRecorder) {
+    if (hadMediaRecorder) {
       mutableGlobal.MediaRecorder = originalMediaRecorder
     } else {
-
-      mutableGlobal.MediaRecorder = undefined
-
-      delete mutableGlobal.MediaRecorder
-
+      Reflect.deleteProperty(mutableGlobal, 'MediaRecorder')
     }
   })
 

--- a/apps/web/src/world/world.ts
+++ b/apps/web/src/world/world.ts
@@ -42,10 +42,10 @@ export interface WorldConfig {
 }
 
 export interface WorldUpdateInput {
-  jump: boolean
-  start: boolean
-  pause: boolean
-  restart: boolean
+  jump?: boolean
+  start?: boolean
+  pause?: boolean
+  restart?: boolean
   jumpHoldDuration: number
   pointer?: Vector2
   dt: number


### PR DESCRIPTION
## Summary
- fix the mocked canvas context to satisfy CanvasRenderingContext2D typings in visual renderer tests
- add explicit canvas pattern repetition union to avoid relying on DOM lib globals
- make global MediaRecorder/MediaStream stubs and world update input align with optional runtime behaviour

## Testing
- pnpm run build:web
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4fe80152c8323a6cf94923e2ad6a8