### PR TITLE
feat: improve mobile responsive layout

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -106,7 +106,8 @@ describe('App', () => {
   it('disables UI transitions when reduced motion is preferred', () => {
     const media = setupMatchMedia({
       '(prefers-reduced-motion: reduce)': true,
-      '(min-width: 768px)': false,
+      '(min-width: 480px)': false,
+      '(min-width: 640px)': false,
     })
 
     try {
@@ -126,7 +127,8 @@ describe('App', () => {
   it('renders desktop layout when md breakpoint matches', () => {
     const media = setupMatchMedia({
       '(prefers-reduced-motion: reduce)': false,
-      '(min-width: 768px)': true,
+      '(min-width: 480px)': true,
+      '(min-width: 640px)': true,
     })
 
     try {
@@ -142,7 +144,8 @@ describe('App', () => {
   it('shows start overlay before the run and after pausing', async () => {
     const media = setupMatchMedia({
       '(prefers-reduced-motion: reduce)': false,
-      '(min-width: 768px)': true,
+      '(min-width: 480px)': true,
+      '(min-width: 640px)': true,
     })
 
     try {
@@ -174,7 +177,8 @@ describe('App', () => {
   it('switches to mobile layout when the breakpoint shrinks', async () => {
     const media = setupMatchMedia({
       '(prefers-reduced-motion: reduce)': false,
-      '(min-width: 768px)': true,
+      '(min-width: 480px)': true,
+      '(min-width: 640px)': true,
     })
 
     try {
@@ -182,7 +186,7 @@ describe('App', () => {
       expect(screen.queryByLabelText(/open controls/i)).not.toBeInTheDocument()
 
       act(() => {
-        media.setMatches('(min-width: 768px)', false)
+        media.setMatches('(min-width: 640px)', false)
       })
 
       await waitFor(() => expect(screen.getByLabelText(/open controls/i)).toBeInTheDocument())
@@ -194,7 +198,8 @@ describe('App', () => {
   it('opens the bottom sheet via the FAB on mobile', async () => {
     const media = setupMatchMedia({
       '(prefers-reduced-motion: reduce)': false,
-      '(min-width: 768px)': false,
+      '(min-width: 480px)': false,
+      '(min-width: 640px)': false,
     })
 
     try {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -203,20 +203,20 @@ export function App() {
     personalBestScore: 0,
   }))
 
-  const isSmallViewport = useMediaQuery('(min-width: 640px)')
-  const isDesktop = useMediaQuery('(min-width: 768px)')
+  const isWideMobile = useMediaQuery('(min-width: 480px)')
+  const isTabletOrLarger = useMediaQuery('(min-width: 640px)')
   const [isSheetOpen, setSheetOpen] = useState(false)
 
   const canvasAspectStyle = useMemo(
-    () => ({ aspectRatio: isSmallViewport ? '18 / 9' : '16 / 9' }),
-    [isSmallViewport]
+    () => ({ aspectRatio: isWideMobile ? '18 / 9' : '16 / 9' }),
+    [isWideMobile]
   )
 
   useEffect(() => {
-    if (isDesktop) {
+    if (isTabletOrLarger) {
       setSheetOpen(false)
     }
-  }, [isDesktop])
+  }, [isTabletOrLarger])
 
   useEffect(() => {
     writeRecentTracks(recentTracks)
@@ -1177,8 +1177,8 @@ export function App() {
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
-      <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-10 px-6 py-12">
-        {isDesktop ? (
+      <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-8 px-4 pb-20 pt-10 sm:gap-10 sm:px-6 sm:pb-24 sm:pt-12">
+        {isTabletOrLarger ? (
           <div className="grid gap-10 md:grid-cols-[minmax(0,360px)_minmax(0,1fr)] lg:grid-cols-[minmax(0,380px)_minmax(0,1fr)]">
             <section className="rounded-3xl border border-white/10 bg-slate-900/50 p-5 shadow-xl ring-1 ring-white/10">
               {renderTrackControls(true)}
@@ -1213,7 +1213,7 @@ export function App() {
           </div>
         )}
       </main>
-      {!isDesktop ? (
+      {!isTabletOrLarger ? (
         <>
           <button
             type="button"
@@ -1225,6 +1225,10 @@ export function App() {
               'fixed bottom-6 right-6 z-50 inline-flex h-14 w-14 items-center justify-center rounded-full bg-cyan-400 text-slate-950 shadow-2xl transition md:hidden focus:outline-none focus:ring-2 focus:ring-cyan-200 focus:ring-offset-2 focus:ring-offset-slate-950',
               isSheetOpen && 'translate-y-12 opacity-0 pointer-events-none',
             )}
+            style={{
+              bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1.5rem)',
+              right: 'calc(env(safe-area-inset-right, 0px) + 1.5rem)',
+            }}
           >
             <svg
               viewBox="0 0 24 24"

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -31,8 +31,18 @@ canvas {
 .telemetry-scroll {
   -ms-overflow-style: none;
   scrollbar-width: none;
+  scroll-snap-type: x proximity;
+  -webkit-overflow-scrolling: touch;
 }
 
 .telemetry-scroll::-webkit-scrollbar {
   display: none;
+}
+
+.telemetry-scroll > * {
+  scroll-snap-align: start;
+}
+
+.sheet-safe-area {
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 2rem);
 }

--- a/apps/web/src/ui/BottomSheet.tsx
+++ b/apps/web/src/ui/BottomSheet.tsx
@@ -32,6 +32,7 @@ const BottomSheet = ({
   id,
 }: BottomSheetProps) => {
   const tracker = useRef<PointerTracker>({ startY: 0, pointerId: null })
+  const rootRef = useRef<HTMLDivElement | null>(null)
   const [dragOffset, setDragOffset] = useState(0)
   const [isDragging, setIsDragging] = useState(false)
   const handleRef = useRef<HTMLButtonElement | null>(null)
@@ -40,6 +41,19 @@ const BottomSheet = ({
     if (!open) {
       setDragOffset(0)
       setIsDragging(false)
+    }
+  }, [open])
+
+  useEffect(() => {
+    const node = rootRef.current
+    if (!node) {
+      return
+    }
+
+    if (!open) {
+      node.setAttribute('inert', '')
+    } else {
+      node.removeAttribute('inert')
     }
   }, [open])
 
@@ -120,7 +134,11 @@ const BottomSheet = ({
   }
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-40 flex flex-col items-center md:hidden" aria-hidden={!open}>
+    <div
+      ref={rootRef}
+      className="fixed inset-x-0 bottom-0 z-40 flex flex-col items-center md:hidden"
+      aria-hidden={!open}
+    >
       <div
         className="pointer-events-auto fixed inset-0 z-30 bg-slate-950/70 backdrop-blur-sm"
         style={overlayStyle}
@@ -137,7 +155,7 @@ const BottomSheet = ({
         style={sheetStyle}
         data-testid="bottom-sheet"
       >
-        <div className="flex flex-col gap-4 px-6 pb-8 pt-4">
+        <div className="flex flex-col gap-4 px-6 pb-8 pt-4 sheet-safe-area">
           <button
             type="button"
             aria-label="Drag handle"

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -3,6 +3,14 @@ import type { Config } from 'tailwindcss'
 export default {
   content: ['index.html', './src/**/*.{ts,tsx}'],
   theme: {
+    screens: {
+      xs: '0px',
+      sm: '480px',
+      md: '640px',
+      lg: '1024px',
+      xl: '1280px',
+      '2xl': '1536px',
+    },
     extend: {
       fontFamily: {
         sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],


### PR DESCRIPTION
## Summary
- align Tailwind screens and media query usage with the responsive UX spec
- refresh mobile layout spacing, FAB positioning, and bottom sheet accessibility & safe-area handling
- enable swipe-friendly telemetry chips and update tests for the new breakpoints

## Testing
- pnpm lint
- pnpm --filter @the-path/web exec vitest run
- pnpm --filter @the-path/web exec playwright test --reporter=list *(fails: browsers not installed in container)*
- pnpm test:ci *(fails: missing @vitest/coverage-v8 dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fe86b9388323947b3cc979359283