### PR TITLE
feat: polish ui surfaces and accessibility

### DIFF
--- a/apps/web/UX_SPEC.md
+++ b/apps/web/UX_SPEC.md
@@ -52,6 +52,12 @@ This document expands on the README to describe the responsive behaviour the fro
 - Defer non-essential telemetry rendering until after first interaction on `xs`/`sm`.
 - Respect `prefers-reduced-motion`; disable marquee + parallax in that mode.
 
+## Visual language
+
+- Global background blends a deep slate base (`surface.base`) with cyan and violet mesh gradients. Panels use `surface.raised` with translucent overlays and a `panel` drop shadow to lift above the playfield without sacrificing contrast.
+- Accent cyan drives primary actions (`accent.cyan`), supported by magenta highlights in secondary badges. Ensure text on accent surfaces remains `text-slate-950`/`text-slate-100` for ≥ 4.5:1 contrast.
+- Cards, telemetry chips, and dialogs share the same 24 px radius treatment, `border.border-subtle`, and `focus` ring token for consistent accessibility cues across input states.
+
 ## Audio track loading UX flow
 
 1. Surface a primary button labelled «Загрузить трек» within the control surface (toolbar on desktop, bottom sheet on mobile). Activating it opens the system file picker pre-filtered to OGG/MP3/WAV extensions. Mirror this affordance with a drag-and-drop target covering the canvas so users can drop files directly.

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -800,11 +800,11 @@ export function App() {
     <div className="space-y-5">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="space-y-1">
-          <p className="text-xs uppercase tracking-[0.3em] text-cyan-300/80">Soundtrack</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-accent-cyan/80">Soundtrack</p>
           <h2 className="text-2xl font-semibold text-slate-50 sm:text-3xl">{selectedTrack?.title}</h2>
-          <p className="text-sm text-slate-400">{selectedTrack?.artist}</p>
+          <p className="text-sm text-slate-300">{selectedTrack?.artist}</p>
           {selectedTrack?.description ? (
-            <p className="text-sm text-slate-400/80">{selectedTrack.description}</p>
+            <p className="text-sm text-slate-300/80">{selectedTrack.description}</p>
           ) : null}
         </div>
         <div className="flex flex-wrap items-center gap-2">
@@ -812,7 +812,7 @@ export function App() {
             type="button"
             onClick={handleTogglePlayback}
             disabled={audioState === 'loading' || !audioSupported}
-            className="inline-flex items-center justify-center rounded-full border border-cyan-400/60 bg-cyan-400/15 px-4 py-2 text-sm font-semibold text-cyan-100 shadow-lg shadow-cyan-500/20 transition hover:bg-cyan-400/25 disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex items-center justify-center rounded-full border border-accent-cyan/60 bg-accent-cyan/15 px-4 py-2 text-sm font-semibold text-accent-cyan shadow-glow transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base hover:bg-accent-cyan/25 disabled:cursor-not-allowed disabled:opacity-60"
           >
             {audioSupported
               ? audioState === 'playing'
@@ -823,27 +823,27 @@ export function App() {
           <button
             type="button"
             onClick={handleRestartTrack}
-            className="inline-flex items-center justify-center rounded-full border border-slate-200/40 bg-white/10 px-4 py-2 text-sm font-semibold text-slate-100 shadow-lg shadow-slate-900/40 transition hover:bg-white/20"
+            className="inline-flex items-center justify-center rounded-full border border-border-subtle bg-surface-overlay/70 px-4 py-2 text-sm font-semibold text-slate-100 shadow-panel transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base hover:bg-surface-overlay"
           >
             Restart track
           </button>
         </div>
       </div>
       <div className="space-y-3">
-        <div className="relative h-2 overflow-hidden rounded-full bg-slate-800/60">
+        <div className="relative h-2 overflow-hidden rounded-full bg-surface-overlay/70">
           <div
             data-testid="audio-progress-fill"
-            className="absolute inset-y-0 left-0 bg-cyan-400/80 transition-all"
+            className="absolute inset-y-0 left-0 bg-accent-cyan/80 transition-all"
             style={{
               width: `${Math.round(clamp01(audioProgress.progress) * 100)}%`,
               transition: prefersReducedMotion ? 'none' : undefined,
             }}
           />
         </div>
-        <div className="flex items-center justify-between text-xs text-slate-400 sm:text-sm">
-          <span className="font-mono text-slate-300">{formatTime(audioProgress.time)}</span>
+        <div className="flex items-center justify-between text-xs text-slate-300 sm:text-sm">
+          <span className="font-mono text-slate-200">{formatTime(audioProgress.time)}</span>
           <span>{playbackStatus}</span>
-          <span className="font-mono text-slate-300">{formatTime(audioProgress.duration)}</span>
+          <span className="font-mono text-slate-200">{formatTime(audioProgress.duration)}</span>
         </div>
       </div>
     </div>
@@ -859,10 +859,10 @@ export function App() {
             type="button"
             onClick={() => handleSelectTrack(track.id)}
             className={classNames(
-              'inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm transition',
+              'inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base',
               isSelected
-                ? 'bg-emerald-500/25 text-emerald-100 ring-1 ring-emerald-400/60'
-                : 'bg-slate-800/70 text-slate-300 hover:bg-slate-700/70',
+                ? 'bg-emerald-500/20 text-emerald-100 ring-1 ring-emerald-400/60 shadow-glow'
+                : 'bg-surface-overlay/70 text-slate-300 hover:bg-surface-overlay/90',
             )}
           >
             <span className="font-medium">{track.title}</span>
@@ -879,10 +879,10 @@ export function App() {
             type="button"
             onClick={() => handleSelectTrack(track.id)}
             className={classNames(
-              'inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm transition',
+              'inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base',
               isSelected
-                ? 'bg-cyan-500/20 text-cyan-100 ring-1 ring-cyan-400/50'
-                : 'bg-slate-800/70 text-slate-300 hover:bg-slate-700/70',
+                ? 'bg-accent-cyan/20 text-accent-cyan ring-1 ring-accent-cyan/60 shadow-glow'
+                : 'bg-surface-overlay/70 text-slate-300 hover:bg-surface-overlay/90',
             )}
           >
             <span className="font-medium">{track.title}</span>
@@ -903,10 +903,10 @@ export function App() {
         onClearError={() => setUploadError(null)}
       />
       {recentTracks.length > 0 ? (
-        <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-4 text-sm shadow-lg shadow-slate-900/30">
+        <div className="rounded-2xl border border-border-subtle bg-surface-raised/80 p-4 text-sm shadow-panel">
           <div className="flex items-center justify-between gap-2">
-            <p className="text-xs uppercase tracking-[0.3em] text-cyan-300/80">Последние треки</p>
-            <span className="text-[0.65rem] text-slate-500">
+            <p className="text-xs uppercase tracking-[0.3em] text-accent-cyan/80">Последние треки</p>
+            <span className="text-[0.65rem] text-slate-400">
               Запоминаем до {MAX_RECENT_TRACKS} последних загрузок за сессию
             </span>
           </div>
@@ -918,11 +918,11 @@ export function App() {
                   key={`recent-${entry.id}`}
                   type="button"
                   onClick={() => handleSelectRecentTrack(entry)}
-                  className="flex w-full items-center justify-between rounded-xl border border-slate-200/20 bg-slate-800/60 px-3 py-2 text-left transition hover:bg-slate-700/60"
+                  className="flex w-full items-center justify-between rounded-xl border border-border-subtle bg-surface-overlay/70 px-3 py-2 text-left transition hover:bg-surface-overlay/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base"
                 >
                   <span className="flex flex-col text-xs">
-                    <span className="font-semibold text-slate-200">{entry.title}</span>
-                    <span className="text-slate-400">{formatTime(entry.duration)} · ~{Math.round(entry.bpm)} BPM</span>
+                    <span className="font-semibold text-slate-100">{entry.title}</span>
+                    <span className="text-slate-300">{formatTime(entry.duration)} · ~{Math.round(entry.bpm)} BPM</span>
                   </span>
                   <span
                     className={classNames(
@@ -952,23 +952,23 @@ export function App() {
   const renderScoreboardCard = (className?: string) => (
     <div
       className={classNames(
-        'w-full space-y-1 rounded-2xl border border-white/10 bg-slate-900/60 px-4 py-3 shadow-lg ring-1 ring-white/10',
+        'w-full space-y-1 rounded-2xl border border-border-subtle bg-surface-raised/80 px-4 py-3 shadow-panel ring-1 ring-white/10 backdrop-blur',
         className,
       )}
     >
-      <p className="text-xs uppercase tracking-[0.3em] text-cyan-300/80">Seed</p>
-      <p className="font-mono text-lg font-semibold text-cyan-100">{hud.seed}</p>
-      <div className="grid grid-cols-3 gap-3 pt-2 text-sm text-slate-300 sm:text-base">
+      <p className="text-xs uppercase tracking-[0.3em] text-accent-cyan/80">Seed</p>
+      <p className="font-mono text-lg font-semibold text-accent-cyan">{hud.seed}</p>
+      <div className="grid grid-cols-3 gap-3 pt-2 text-sm text-slate-200 sm:text-base">
         <div>
-          <p className="text-xs uppercase tracking-[0.3em] text-cyan-300/60">Score</p>
+          <p className="text-xs uppercase tracking-[0.3em] text-accent-cyan/60">Score</p>
           <p className="font-mono text-2xl font-semibold text-slate-50 tabular-nums">{padScore(hud.score)}</p>
         </div>
         <div>
-          <p className="text-xs uppercase tracking-[0.3em] text-cyan-300/60">Combo</p>
+          <p className="text-xs uppercase tracking-[0.3em] text-accent-cyan/60">Combo</p>
           <p className="font-mono text-2xl font-semibold text-slate-50">x{hud.combo}</p>
         </div>
         <div>
-          <p className="text-xs uppercase tracking-[0.3em] text-cyan-300/60">Best</p>
+          <p className="text-xs uppercase tracking-[0.3em] text-accent-cyan/60">Best</p>
           <p className="font-mono text-2xl font-semibold text-slate-50">x{hud.bestCombo}</p>
         </div>
       </div>
@@ -986,21 +986,21 @@ export function App() {
   const renderRecorderCard = (className?: string) => (
     <div
       className={classNames(
-        'w-full space-y-3 rounded-2xl border border-white/10 bg-slate-900/60 px-4 py-3 shadow-lg ring-1 ring-white/10',
+        'w-full space-y-3 rounded-2xl border border-border-subtle bg-surface-raised/80 px-4 py-3 shadow-panel ring-1 ring-white/10 backdrop-blur',
         className,
       )}
     >
-      <p className="text-xs uppercase tracking-[0.3em] text-cyan-300/80">Recorder</p>
+      <p className="text-xs uppercase tracking-[0.3em] text-accent-cyan/80">Recorder</p>
       <div className="flex flex-wrap gap-2">
         <button
           type="button"
           onClick={handleToggleRecording}
           disabled={!recordingSupported}
           className={classNames(
-            'inline-flex flex-1 items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-60',
+            'inline-flex flex-1 items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base disabled:cursor-not-allowed disabled:opacity-60',
             recordingState === 'recording'
               ? 'border border-rose-400/60 bg-rose-500/20 text-rose-100 shadow-lg shadow-rose-500/20 hover:bg-rose-500/30'
-              : 'border border-cyan-400/60 bg-cyan-400/15 text-cyan-100 shadow-lg shadow-cyan-500/20 hover:bg-cyan-400/25',
+              : 'border border-accent-cyan/60 bg-accent-cyan/15 text-accent-cyan shadow-glow hover:bg-accent-cyan/25',
           )}
         >
           {recordButtonLabel}
@@ -1009,29 +1009,29 @@ export function App() {
           type="button"
           onClick={handleSaveClip}
           disabled={saveDisabled}
-          className="inline-flex flex-1 items-center justify-center rounded-full border border-slate-200/40 bg-white/10 px-4 py-2 text-sm font-semibold text-slate-100 shadow-lg shadow-slate-900/40 transition hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex flex-1 items-center justify-center rounded-full border border-border-subtle bg-surface-overlay/70 px-4 py-2 text-sm font-semibold text-slate-100 shadow-panel transition hover:bg-surface-overlay disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base"
         >
           {isSavingClip ? 'Saving…' : 'Save clip'}
         </button>
       </div>
       <div className="space-y-1">
-        <div className="relative h-1.5 overflow-hidden rounded-full bg-slate-800/60">
+        <div className="relative h-1.5 overflow-hidden rounded-full bg-surface-overlay/70">
           <div
             data-testid="recorder-progress-fill"
-            className="absolute inset-y-0 left-0 bg-cyan-400/80 transition-all"
+            className="absolute inset-y-0 left-0 bg-accent-cyan/80 transition-all"
             style={{
               width: `${Math.round(bufferRatio * 100)}%`,
               transition: prefersReducedMotion ? 'none' : undefined,
             }}
           />
         </div>
-        <div className="flex items-center justify-between text-[0.7rem] text-slate-400">
+        <div className="flex items-center justify-between text-[0.7rem] text-slate-300">
           <span>{bufferedLabel}s buffered</span>
           <span>{bufferLimitLabel}s max</span>
         </div>
       </div>
       <div className="space-y-1 text-[0.7rem]">
-        <p className="text-slate-400">{recordingStatus}</p>
+        <p className="text-slate-300">{recordingStatus}</p>
         {recordingError ? <p className="text-rose-300">{recordingError}</p> : null}
       </div>
     </div>
@@ -1048,21 +1048,21 @@ export function App() {
         type="button"
         onClick={handlePauseRun}
         disabled={hud.status !== 'running'}
-        className="inline-flex flex-1 items-center justify-center rounded-full border border-emerald-400/50 bg-emerald-400/10 px-4 py-2 text-sm font-semibold text-emerald-100 shadow-lg shadow-emerald-500/20 transition hover:bg-emerald-400/20 disabled:cursor-not-allowed disabled:opacity-60"
+        className="inline-flex flex-1 items-center justify-center rounded-full border border-emerald-400/50 bg-emerald-500/15 px-4 py-2 text-sm font-semibold text-emerald-100 shadow-lg shadow-emerald-500/20 transition hover:bg-emerald-500/25 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base"
       >
         Pause run
       </button>
       <button
         type="button"
         onClick={handleRestart}
-        className="inline-flex flex-1 items-center justify-center rounded-full border border-cyan-400/50 bg-cyan-400/10 px-4 py-2 text-sm font-semibold text-cyan-100 shadow-lg shadow-cyan-500/20 transition hover:bg-cyan-400/20"
+        className="inline-flex flex-1 items-center justify-center rounded-full border border-accent-cyan/60 bg-accent-cyan/15 px-4 py-2 text-sm font-semibold text-accent-cyan shadow-glow transition hover:bg-accent-cyan/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base"
       >
         Restart run
       </button>
       <button
         type="button"
         onClick={handleNewSeed}
-        className="inline-flex flex-1 items-center justify-center rounded-full border border-slate-200/30 bg-white/10 px-4 py-2 text-sm font-semibold text-slate-100 shadow-lg shadow-slate-900/40 transition hover:bg-white/20"
+        className="inline-flex flex-1 items-center justify-center rounded-full border border-border-subtle bg-surface-overlay/70 px-4 py-2 text-sm font-semibold text-slate-100 shadow-panel transition hover:bg-surface-overlay focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base"
       >
         New seed
       </button>
@@ -1071,8 +1071,8 @@ export function App() {
 
   const heroHeader = (
     <header className="flex flex-col gap-3 text-pretty text-center md:text-left">
-      <p className="text-xs font-semibold uppercase tracking-[0.4em] text-cyan-300/80">the path · reactive beat runner</p>
-      <h1 className="text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
+      <p className="text-xs font-semibold uppercase tracking-[0.4em] text-accent-cyan/80">the path · reactive beat runner</p>
+      <h1 className="text-balance text-4xl font-semibold tracking-tight text-slate-50 sm:text-5xl">
         Calibrate the route through rhythm-synced obstacles
       </h1>
       <p className="text-base text-slate-300 sm:text-lg">
@@ -1084,7 +1084,7 @@ export function App() {
 
   const canvasSection = (
     <section
-      className="relative w-full overflow-hidden rounded-3xl border border-white/10 bg-slate-900/60 shadow-2xl ring-1 ring-white/10"
+      className="relative w-full overflow-hidden rounded-3xl border border-border-strong bg-surface-raised/80 shadow-panel ring-1 ring-white/10 backdrop-blur"
     >
       <canvas
         ref={canvasRef}
@@ -1104,14 +1104,14 @@ export function App() {
               {renderRecorderCard('pointer-events-auto w-full max-w-xs sm:w-64')}
               {renderRunActions('pointer-events-auto')}
             </div>
-            <div className="pointer-events-auto flex w-full flex-wrap items-center gap-3 rounded-2xl bg-slate-900/50 px-4 py-3 text-xs text-slate-300 ring-1 ring-white/10 sm:justify-between sm:text-sm">
+            <div className="pointer-events-auto flex w-full flex-wrap items-center gap-3 rounded-2xl bg-surface-overlay/70 px-4 py-3 text-xs text-slate-200 ring-1 ring-white/10 sm:justify-between sm:text-sm">
               <StatusMarquee
                 message={statusMessage}
                 prefersReducedMotion={prefersReducedMotion}
-                className="w-full rounded-xl border border-white/10 bg-slate-900/70 px-3 py-2 text-left text-xs text-slate-200 sm:flex-1"
+                className="w-full rounded-xl border border-border-subtle bg-surface-raised/80 px-3 py-2 text-left text-xs text-slate-100 sm:flex-1"
                 innerClassName="gap-12"
               />
-              <p className="font-mono text-[0.8rem] text-slate-400 sm:text-xs">
+              <p className="font-mono text-[0.8rem] text-slate-300 sm:text-xs">
                 Fixed timestep · deterministic PRNG · Beat generator BPM {selectedTrack?.bpm ?? 108}
               </p>
             </div>
@@ -1119,17 +1119,17 @@ export function App() {
         ) : null}
       </div>
       {showStartOverlay ? (
-        <div className="pointer-events-auto absolute inset-0 flex items-center justify-center bg-slate-950/60 px-6 py-8 text-center backdrop-blur-sm">
+        <div className="pointer-events-auto absolute inset-0 flex items-center justify-center bg-surface-overlay/90 px-6 py-8 text-center backdrop-blur-sm">
           <button
             type="button"
             onClick={handleStartRun}
             data-testid="start-overlay"
-            className="flex w-full max-w-md flex-col items-center gap-3 rounded-3xl border border-cyan-400/50 bg-slate-900/80 px-6 py-8 text-center text-slate-100 shadow-2xl shadow-cyan-500/20 transition hover:bg-slate-900/70 focus:outline-none focus:ring-2 focus:ring-cyan-200 focus:ring-offset-2 focus:ring-offset-slate-950"
+            className="flex w-full max-w-md flex-col items-center gap-3 rounded-3xl border border-accent-cyan/60 bg-surface-raised/90 px-6 py-8 text-center text-slate-100 shadow-panel transition hover:bg-surface-raised focus:outline-none focus:ring-2 focus:ring-focus focus:ring-offset-2 focus:ring-offset-surface-base"
           >
-            <span className="text-xs uppercase tracking-[0.3em] text-cyan-300/80">{isPaused ? 'Paused' : 'Ready'}</span>
+            <span className="text-xs uppercase tracking-[0.3em] text-accent-cyan/80">{isPaused ? 'Paused' : 'Ready'}</span>
             <span className="text-2xl font-semibold text-slate-50 sm:text-3xl">{startOverlayPrimary}</span>
-            <span className="text-sm text-slate-300 sm:text-base">{startOverlaySecondary}</span>
-            <span className="text-xs text-slate-500">{startOverlayHint}</span>
+            <span className="text-sm text-slate-200 sm:text-base">{startOverlaySecondary}</span>
+            <span className="text-xs text-slate-400">{startOverlayHint}</span>
           </button>
         </div>
       ) : null}
@@ -1165,22 +1165,22 @@ export function App() {
       {telemetryItems.map((item) => (
         <div
           key={item.key}
-          className="min-w-[160px] rounded-2xl border border-white/10 bg-slate-900/70 px-4 py-3 shadow-lg sm:min-w-0"
+          className="min-w-[160px] rounded-2xl border border-border-subtle bg-surface-raised/80 px-4 py-3 shadow-panel sm:min-w-0"
         >
-          <p className="text-xs uppercase tracking-[0.3em] text-cyan-300/80">{item.label}</p>
+          <p className="text-xs uppercase tracking-[0.3em] text-accent-cyan/80">{item.label}</p>
           <p className="font-mono text-lg font-semibold text-slate-50">{item.value}</p>
-          <p className="text-xs text-slate-400">{item.description}</p>
+          <p className="text-xs text-slate-300">{item.description}</p>
         </div>
       ))}
     </div>
   )
 
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100">
+    <div className="min-h-screen bg-surface-base text-slate-100">
       <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-10 px-6 py-12">
         {isDesktop ? (
           <div className="grid gap-10 md:grid-cols-[minmax(0,360px)_minmax(0,1fr)] lg:grid-cols-[minmax(0,380px)_minmax(0,1fr)]">
-            <section className="rounded-3xl border border-white/10 bg-slate-900/50 p-5 shadow-xl ring-1 ring-white/10">
+            <section className="rounded-3xl border border-border-strong bg-surface-raised/80 p-5 shadow-panel ring-1 ring-white/10 backdrop-blur">
               {renderTrackControls(true)}
             </section>
             <div className="flex flex-col gap-10">
@@ -1193,19 +1193,19 @@ export function App() {
           <div className="flex flex-col gap-8">
             <div className="space-y-4">
               {canvasSection}
-              <section className="rounded-3xl border border-white/10 bg-slate-900/60 p-4 shadow-xl ring-1 ring-white/10">
+              <section className="rounded-3xl border border-border-strong bg-surface-raised/80 p-4 shadow-panel ring-1 ring-white/10 backdrop-blur">
                 {renderRunActions('w-full', 'row')}
               </section>
             </div>
             <div className="space-y-6">
               {heroHeader}
-              <section className="rounded-3xl border border-white/10 bg-slate-900/50 p-5 shadow-xl ring-1 ring-white/10">
+              <section className="rounded-3xl border border-border-strong bg-surface-raised/80 p-5 shadow-panel ring-1 ring-white/10 backdrop-blur">
                 {renderTrackSummary()}
               </section>
               <StatusMarquee
                 message={statusMessage}
                 prefersReducedMotion={prefersReducedMotion}
-                className="rounded-full border border-cyan-400/30 bg-cyan-500/10 px-4 py-2 text-xs text-cyan-100 shadow-inner"
+                className="rounded-full border border-accent-cyan/50 bg-accent-cyan/15 px-4 py-2 text-xs text-accent-cyan shadow-glow"
               />
               {telemetryChips}
             </div>
@@ -1222,7 +1222,7 @@ export function App() {
             aria-controls="mobile-controls"
             onClick={() => setSheetOpen(true)}
             className={classNames(
-              'fixed bottom-6 right-6 z-50 inline-flex h-14 w-14 items-center justify-center rounded-full bg-cyan-400 text-slate-950 shadow-2xl transition md:hidden focus:outline-none focus:ring-2 focus:ring-cyan-200 focus:ring-offset-2 focus:ring-offset-slate-950',
+              'fixed bottom-6 right-6 z-50 inline-flex h-14 w-14 items-center justify-center rounded-full bg-accent-cyan text-slate-950 shadow-glow transition hover:bg-accent-cyan/90 md:hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base',
               isSheetOpen && 'translate-y-12 opacity-0 pointer-events-none',
             )}
           >
@@ -1260,10 +1260,10 @@ export function App() {
               <StatusMarquee
                 message={statusMessage}
                 prefersReducedMotion={prefersReducedMotion}
-                className="rounded-2xl border border-white/10 bg-slate-900/80 px-4 py-2 text-xs text-slate-200"
+                className="rounded-2xl border border-border-subtle bg-surface-raised/90 px-4 py-2 text-xs text-slate-100"
                 innerClassName="gap-12"
               />
-              <p className="text-xs text-slate-400">
+              <p className="text-xs text-slate-300">
                 Fixed timestep · deterministic PRNG · Beat generator BPM {selectedTrack?.bpm ?? 108}
               </p>
               {renderTrackControls(false)}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2,15 +2,47 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  color-scheme: dark;
-}
+@layer base {
+  :root {
+    color-scheme: dark;
+  }
 
-body {
-  margin: 0;
-  min-height: 100vh;
-  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-  background-color: rgb(2 6 23);
+  body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    background-color: rgb(2 6 23);
+    background-image:
+      radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.18), transparent 55%),
+      radial-gradient(circle at 80% 15%, rgba(124, 58, 237, 0.18), transparent 60%),
+      radial-gradient(circle at 10% 80%, rgba(34, 211, 238, 0.14), transparent 55%),
+      linear-gradient(160deg, rgba(15, 23, 42, 0.85), rgba(2, 6, 23, 0.95));
+    background-attachment: fixed;
+    background-size: 960px 960px, 1024px 1024px, 900px 900px, cover;
+    color: rgb(226 232 240);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  ::selection {
+    background-color: rgba(56, 189, 248, 0.35);
+    color: rgb(241 245 249);
+  }
+
+  a {
+    color: rgb(165 243 252);
+    text-decoration: none;
+    transition: color 150ms ease;
+  }
+
+  a:focus-visible,
+  a:hover {
+    color: rgb(224 231 255);
+  }
+
+  :is(button, [href], input, textarea, select):focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.45);
+  }
 }
 
 canvas {

--- a/apps/web/src/ui/BottomSheet.tsx
+++ b/apps/web/src/ui/BottomSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react'
+import { useEffect, useId, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react'
 
 interface BottomSheetProps {
   open: boolean
@@ -35,6 +35,9 @@ const BottomSheet = ({
   const [dragOffset, setDragOffset] = useState(0)
   const [isDragging, setIsDragging] = useState(false)
   const handleRef = useRef<HTMLButtonElement | null>(null)
+  const autoId = useId()
+  const sheetId = id ?? autoId
+  const titleId = title ? `${sheetId}-title` : undefined
 
   useEffect(() => {
     if (!open) {
@@ -120,24 +123,25 @@ const BottomSheet = ({
   }
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-40 flex flex-col items-center md:hidden" aria-hidden={!open}>
+    <div className="fixed inset-x-0 bottom-0 z-40 flex flex-col items-center px-3 md:hidden" aria-hidden={!open}>
       <div
-        className="pointer-events-auto fixed inset-0 z-30 bg-slate-950/70 backdrop-blur-sm"
+        className="pointer-events-auto fixed inset-0 z-30 bg-surface-overlay/80 backdrop-blur-sm"
         style={overlayStyle}
         aria-hidden="true"
         onClick={() => onOpenChange(false)}
         data-testid="bottom-sheet-overlay"
       />
       <div
-        className="z-40 w-full max-w-3xl rounded-t-3xl border border-white/10 bg-slate-900/95 shadow-[0_-20px_45px_rgba(8,47,73,0.35)]"
+        className="z-40 w-full max-w-3xl overflow-hidden rounded-t-3xl border border-border-strong bg-surface-raised/95 shadow-panel backdrop-blur-xl"
         role="dialog"
         aria-modal="true"
         aria-hidden={!open}
-        id={id}
+        aria-labelledby={titleId}
+        id={sheetId}
         style={sheetStyle}
         data-testid="bottom-sheet"
       >
-        <div className="flex flex-col gap-4 px-6 pb-8 pt-4">
+        <div className="flex flex-col gap-4 px-6 pb-8 pt-5">
           <button
             type="button"
             aria-label="Drag handle"
@@ -146,14 +150,18 @@ const BottomSheet = ({
             onPointerMove={handlePointerMove}
             onPointerUp={handlePointerEnd}
             onPointerCancel={handlePointerEnd}
-            className="mx-auto h-1.5 w-14 touch-none rounded-full bg-slate-500/60"
+            className="mx-auto h-1.5 w-14 touch-none rounded-full bg-white/25"
           />
           <div className="flex items-center justify-between">
-            {title ? <h2 className="text-base font-semibold text-slate-100">{title}</h2> : null}
+            {title ? (
+              <h2 id={titleId} className="text-base font-semibold text-slate-100">
+                {title}
+              </h2>
+            ) : null}
             <button
               type="button"
               onClick={() => onOpenChange(false)}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-700/60 bg-slate-900 text-slate-200 transition hover:bg-slate-800"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border-subtle bg-surface-overlay/80 text-slate-100 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base hover:bg-surface-overlay"
               aria-label="Close controls"
             >
               <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden="true" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -161,8 +169,8 @@ const BottomSheet = ({
               </svg>
             </button>
           </div>
-          <div className="overflow-y-auto pe-2" style={{ maxHeight: '70vh' }}>
-            <div className="space-y-6 pe-2">{children}</div>
+          <div className="overflow-y-auto pe-1" style={{ maxHeight: '70vh' }}>
+            <div className="space-y-6 pe-1">{children}</div>
           </div>
         </div>
       </div>

--- a/apps/web/src/ui/LeadersBoard.tsx
+++ b/apps/web/src/ui/LeadersBoard.tsx
@@ -35,26 +35,26 @@ export const LeadersBoard = ({ sessionBest, personalBest, className }: LeadersBo
   return (
     <div
       className={composeClassName(
-        'w-full space-y-3 rounded-2xl border border-white/10 bg-slate-900/60 px-4 py-3 shadow-lg ring-1 ring-white/10',
+        'w-full space-y-4 rounded-2xl border border-border-subtle bg-surface-raised/80 px-5 py-4 shadow-panel ring-1 ring-white/10 backdrop-blur',
         className,
       )}
     >
       <div className="flex items-center justify-between gap-2">
-        <p className="text-xs uppercase tracking-[0.3em] text-cyan-300/80">Лидеры</p>
-        <span className="text-[0.65rem] uppercase tracking-[0.25em] text-cyan-200/70">Локально</span>
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-accent-cyan/80">Лидеры</p>
+        <span className="text-[0.65rem] uppercase tracking-[0.25em] text-accent-magenta/70">Локально</span>
       </div>
       <dl className="space-y-3">
         {entries.map((entry) => (
           <Entry key={entry.key}>
             <div>
-              <dt className="text-[0.65rem] uppercase tracking-[0.3em] text-cyan-300/60">{entry.label}</dt>
+              <dt className="text-[0.65rem] uppercase tracking-[0.3em] text-accent-cyan/60">{entry.label}</dt>
               <dd className="font-mono text-2xl font-semibold text-slate-50 tabular-nums">{entry.value}</dd>
             </div>
-            <p className="max-w-[160px] text-[0.7rem] text-slate-400">{entry.description}</p>
+            <p className="max-w-[180px] text-[0.7rem] text-slate-300">{entry.description}</p>
           </Entry>
         ))}
       </dl>
-      <div className="rounded-xl border border-dashed border-cyan-400/40 bg-cyan-400/10 px-3 py-2 text-[0.7rem] text-cyan-100">
+      <div className="rounded-xl border border-dashed border-accent-cyan/50 bg-accent-cyan/10 px-3 py-2 text-[0.7rem] text-accent-cyan">
         Синхронизация с сервером: скоро
       </div>
     </div>

--- a/apps/web/src/ui/TrackUpload.tsx
+++ b/apps/web/src/ui/TrackUpload.tsx
@@ -119,23 +119,23 @@ export function TrackUpload({
         type="button"
         onClick={handleButtonClick}
         disabled={disabled || processing}
-        className="inline-flex w-full items-center justify-center rounded-2xl border border-cyan-400/50 bg-slate-900/70 px-4 py-3 text-sm font-semibold text-cyan-100 shadow-inner shadow-cyan-500/20 transition hover:bg-cyan-500/10 disabled:cursor-not-allowed disabled:opacity-60"
+        className="inline-flex w-full items-center justify-center rounded-2xl border border-border-strong bg-surface-overlay/80 px-4 py-3 text-sm font-semibold text-slate-50 shadow-panel transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base hover:bg-surface-overlay disabled:cursor-not-allowed disabled:opacity-60"
       >
         {processing ? 'Анализируем…' : 'Загрузить трек'}
       </button>
 
-      <p className="mt-2 text-xs text-slate-400">
+      <p className="mt-2 text-xs text-slate-300">
         Поддерживаются форматы {describeAcceptedFormats()} · перетащите файл на экран или выберите вручную.
       </p>
       {combinedError ? (
-        <p className="mt-1 text-xs text-rose-300" title={combinedError}>
+        <p className="mt-1 text-xs text-rose-300" title={combinedError} role="alert" aria-live="polite">
           {combinedError}
         </p>
       ) : null}
 
       {dragActive ? (
-        <div className="pointer-events-none fixed inset-0 z-40 flex items-center justify-center bg-slate-950/80 backdrop-blur-sm">
-          <div className="rounded-3xl border border-dashed border-cyan-400/60 bg-cyan-400/10 px-6 py-5 text-center text-sm font-medium text-cyan-100 shadow-2xl shadow-cyan-500/30">
+        <div className="pointer-events-none fixed inset-0 z-40 flex items-center justify-center bg-surface-overlay/90 backdrop-blur-sm">
+          <div className="rounded-3xl border border-dashed border-accent-cyan/60 bg-accent-cyan/10 px-6 py-5 text-center text-sm font-medium text-accent-cyan shadow-2xl shadow-cyan-500/30">
             Отпустите, чтобы загрузить трек
           </div>
         </div>

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -6,19 +6,49 @@ export default {
     extend: {
       fontFamily: {
         sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'monospace'],
       },
       colors: {
         brand: {
           cyan: '#38bdf8',
           slate: '#0f172a',
+          violet: '#7c3aed',
+        },
+        surface: {
+          base: '#020617',
+          sunken: '#040b1a',
+          raised: '#0b1224',
+          overlay: '#111b2f',
+        },
+        accent: {
+          cyan: '#22d3ee',
+          magenta: '#c084fc',
+          amber: '#fbbf24',
+        },
+        border: {
+          subtle: 'rgba(148, 163, 184, 0.18)',
+          strong: 'rgba(148, 163, 184, 0.28)',
         },
       },
       boxShadow: {
         focus: '0 0 0 4px rgba(56, 189, 248, 0.35)',
+        glow: '0 0 0 1px rgba(56, 189, 248, 0.25), 0 20px 50px rgba(8, 47, 73, 0.55)',
+        panel: '0 25px 60px rgba(8, 47, 73, 0.35)',
+      },
+      ringColor: {
+        focus: 'rgba(56, 189, 248, 0.45)',
+      },
+      ringOffsetColor: {
+        surface: '#020617',
+        'surface-base': '#020617',
       },
       aspectRatio: {
         'hero-video': '16 / 9',
         'hero-video-wide': '18 / 9',
+      },
+      backgroundImage: {
+        'mesh-grid':
+          'radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.18), transparent 55%), radial-gradient(circle at 80% 15%, rgba(124, 58, 237, 0.18), transparent 60%), radial-gradient(circle at 10% 80%, rgba(34, 211, 238, 0.14), transparent 55%)',
       },
     },
   },


### PR DESCRIPTION
## Summary
- refresh the Tailwind theme with surface, accent, and focus tokens for consistent dark-mode contrast
- polish core UI panels, marquee, track upload, and bottom sheet styles for better readability and keyboard focus cues
- document the visual language tokens in the UX spec for future implementation guidance

## Testing
- pnpm --filter @the-path/web lint
- pnpm --filter @the-path/web test *(fails: Playwright browsers not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fe914cdc83239fa8c8d1966c54f1