### PR TITLE
test: harden audio upload and recent track flows

### DIFF
--- a/apps/web/src/StatusMarquee.test.tsx
+++ b/apps/web/src/StatusMarquee.test.tsx
@@ -113,4 +113,31 @@ describe('StatusMarquee', () => {
       expect(marquee).toHaveStyle({ animation: 'status-marquee 20s linear infinite' })
     })
   })
+
+  it('disables animation when reduced motion is preferred', async () => {
+    const message = 'Overflowing status message that would otherwise animate'
+    render(<StatusMarquee message={message} prefersReducedMotion />)
+
+    const marquee = screen.getByTestId('status-marquee-content')
+
+    Object.defineProperty(marquee, 'clientWidth', {
+      configurable: true,
+      get: () => 200,
+    })
+
+    Object.defineProperty(marquee, 'scrollWidth', {
+      configurable: true,
+      get: () => 400,
+    })
+
+    act(() => {
+      triggerResize(marquee)
+    })
+
+    await waitFor(() => {
+      expect(marquee).toHaveStyle({ animation: 'none' })
+    })
+
+    expect(screen.getAllByText(message)).toHaveLength(1)
+  })
 })

--- a/apps/web/src/audio/recentTracks.test.ts
+++ b/apps/web/src/audio/recentTracks.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  MAX_RECENT_TRACKS,
+  RECENT_TRACKS_STORAGE_KEY,
+  StoredRecentTrack,
+  readRecentTracks,
+  toManifest,
+  upsertRecentTrack,
+  writeRecentTracks,
+} from './recentTracks'
+
+let trackCounter = 0
+
+const createTrack = (overrides: Partial<StoredRecentTrack> = {}): StoredRecentTrack => ({
+  id: overrides.id ?? `track-${trackCounter++}`,
+  title: overrides.title ?? 'Track',
+  artist: overrides.artist ?? 'Artist',
+  duration: overrides.duration ?? 120,
+  bpm: overrides.bpm ?? 128,
+  createdAt: overrides.createdAt ?? Date.now(),
+})
+
+const createMockStorage = (initial: Record<string, string | null> = {}) => {
+  const store = new Map(Object.entries(initial))
+
+  return {
+    get length() {
+      return store.size
+    },
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value)
+    }),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key)
+    }),
+    clear: vi.fn(() => {
+      store.clear()
+    }),
+    key: vi.fn((index: number) => Array.from(store.keys())[index] ?? null),
+  } satisfies Storage
+}
+
+describe('recentTracks', () => {
+  const now = 1_700_000_000_000
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('readRecentTracks', () => {
+    it('returns an empty array when storage is unavailable', () => {
+      expect(readRecentTracks(undefined)).toEqual([])
+    })
+
+    it('filters out malformed entries', () => {
+      const storage = createMockStorage({
+        [RECENT_TRACKS_STORAGE_KEY]: JSON.stringify([
+          { id: 'valid', title: 'Valid', artist: 'Artist', duration: 120, bpm: 128, createdAt: now },
+          { id: 'missingFields' },
+          'not-an-object',
+        ]),
+      })
+
+      const result = readRecentTracks(storage)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({ id: 'valid' })
+      expect(storage.getItem).toHaveBeenCalledWith(RECENT_TRACKS_STORAGE_KEY)
+    })
+
+    it('ignores broken JSON payloads', () => {
+      const storage = createMockStorage({ [RECENT_TRACKS_STORAGE_KEY]: '{invalid json' })
+      expect(readRecentTracks(storage)).toEqual([])
+    })
+  })
+
+  describe('writeRecentTracks', () => {
+    it('persists the provided payload when storage is available', () => {
+      const storage = createMockStorage()
+      const tracks = [createTrack({ id: 'one' }), createTrack({ id: 'two' })]
+
+      writeRecentTracks(tracks, storage)
+
+      expect(storage.setItem).toHaveBeenCalledTimes(1)
+      expect(storage.setItem).toHaveBeenCalledWith(
+        RECENT_TRACKS_STORAGE_KEY,
+        JSON.stringify(tracks),
+      )
+    })
+  })
+
+  describe('upsertRecentTrack', () => {
+    it('adds new entries and sorts them by recency', () => {
+      const older = createTrack({ id: 'older', createdAt: now - 5000 })
+      const newest = createTrack({ id: 'newest', createdAt: now })
+      const middle = createTrack({ id: 'middle', createdAt: now - 2000 })
+
+      const result = upsertRecentTrack([older, middle], newest)
+
+      expect(result.map((track) => track.id)).toEqual(['newest', 'middle', 'older'])
+    })
+
+    it('deduplicates entries by id and keeps the latest timestamp', () => {
+      const existing = createTrack({ id: 'duplicate', createdAt: now - 10_000 })
+      const updated = createTrack({ id: 'duplicate', createdAt: now })
+
+      const result = upsertRecentTrack([existing], updated)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual(updated)
+    })
+
+    it('enforces the configured limit and tolerates invalid overrides', () => {
+      const baseTracks = Array.from({ length: MAX_RECENT_TRACKS }, (_, index) =>
+        createTrack({ id: `track-${index}`, createdAt: now - index * 1000 }),
+      )
+
+      const extra = createTrack({ id: 'extra', createdAt: now + 1000 })
+
+      const limited = upsertRecentTrack(baseTracks, extra)
+      const withInvalidLimit = upsertRecentTrack(baseTracks, extra, 0)
+
+      expect(limited).toHaveLength(MAX_RECENT_TRACKS)
+      expect(limited[0].id).toBe('extra')
+      expect(withInvalidLimit).toHaveLength(1)
+      expect(withInvalidLimit[0].id).toBe('extra')
+    })
+  })
+
+  describe('toManifest', () => {
+    it('maps stored tracks to manifest entries', () => {
+      const track = createTrack({ id: 'manifest-id', bpm: 100, duration: 321 })
+      const manifest = toManifest(track)
+
+      expect(manifest).toEqual({
+        id: 'manifest-id',
+        title: track.title,
+        artist: track.artist,
+        duration: 321,
+        bpm: 100,
+      })
+    })
+  })
+})

--- a/apps/web/src/audio/uploadValidation.test.ts
+++ b/apps/web/src/audio/uploadValidation.test.ts
@@ -25,6 +25,8 @@ describe('uploadValidation', () => {
     expect(validateAudioFileType(createFile('beat.ogg', ''))).toBeNull()
     expect(validateAudioFileType(createFile('song.mp3', ''))).toBeNull()
     expect(validateAudioFileType(createFile('wave.wav', ''))).toBeNull()
+    expect(validateAudioFileType(createFile('take.WAVE', ''))).toBeNull()
+    expect(validateAudioFileType(createFile('ambience.oga', ''))).toBeNull()
   })
 
   it('rejects unsupported formats', () => {

--- a/apps/web/src/audio/uploadValidation.ts
+++ b/apps/web/src/audio/uploadValidation.ts
@@ -6,7 +6,16 @@ export const ACCEPTED_MIME_TYPES = new Set<string>([
   'audio/x-wav',
 ])
 
-export const ACCEPTED_EXTENSIONS = new Set<string>(['mp3', 'ogg', 'wav'])
+export const ACCEPTED_EXTENSIONS = new Set<string>(['mp3', 'ogg', 'oga', 'wav', 'wave'])
+
+export const FILE_INPUT_ACCEPT = [
+  ...ACCEPTED_MIME_TYPES,
+  '.mp3',
+  '.ogg',
+  '.oga',
+  '.wav',
+  '.wave',
+].join(',')
 
 export const MIN_AUDIO_DURATION_SECONDS = 5
 export const MAX_AUDIO_DURATION_SECONDS = 600

--- a/apps/web/src/ui/TrackUpload.tsx
+++ b/apps/web/src/ui/TrackUpload.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   describeAcceptedFormats,
+  FILE_INPUT_ACCEPT,
   formatValidationErrorMessage,
   validateAudioFileType,
 } from '../audio/uploadValidation'
@@ -109,7 +110,7 @@ export function TrackUpload({
       <input
         ref={inputRef}
         type="file"
-        accept=".ogg,.mp3,.wav"
+        accept={FILE_INPUT_ACCEPT}
         tabIndex={-1}
         className="hidden"
         onChange={(event) => handleFiles(event.target.files)}


### PR DESCRIPTION
## Summary
- extend the audio upload whitelist to cover .oga/.wave files and reuse the same accept string in the UI
- add unit coverage for the recent track persistence helpers, including dedupe and storage error handling
- add a prefers-reduced-motion regression test for the status marquee behaviour

## Testing
- pnpm --filter @the-path/web exec vitest run
- pnpm --filter @the-path/web exec playwright test --pass-with-no-tests

------
https://chatgpt.com/codex/tasks/task_e_68d50b5a3f648323b335787d5b909967