### PR TITLE
Integrate beat-aware WebAudio pipeline with gameplay hooks

### DIFF
--- a/apps/web/src/assets/tracks/index.ts
+++ b/apps/web/src/assets/tracks/index.ts
@@ -15,6 +15,7 @@ export interface AudioTrackManifestEntry {
   duration: number
   bpm: number
   description?: string
+  peaks?: number[]
 }
 
 const SUPPORTED_EXTENSIONS = ['aac', 'flac', 'm4a', 'mp3', 'ogg', 'opus', 'wav', 'webm'] as const

--- a/apps/web/src/audio/eqPresets.ts
+++ b/apps/web/src/audio/eqPresets.ts
@@ -1,0 +1,46 @@
+export interface EqPreset {
+  id: string
+  label: string
+  description?: string
+  bands: {
+    low: number
+    mid: number
+    high: number
+  }
+}
+
+export const EQ_PRESETS: EqPreset[] = [
+  {
+    id: 'flat',
+    label: 'Flat',
+    description: 'Neutral curve without coloration — best for analysis or headphones.',
+    bands: { low: 0, mid: 0, high: 0 },
+  },
+  {
+    id: 'club',
+    label: 'Club',
+    description: 'Accentuated bass and air for high-energy electronic tracks.',
+    bands: { low: 4.5, mid: -1, high: 3.5 },
+  },
+  {
+    id: 'lofi',
+    label: 'Lo-Fi',
+    description: 'Rolled-off highs and mids for chill or retro aesthetics.',
+    bands: { low: -1.5, mid: -2, high: -5 },
+  },
+  {
+    id: 'focus',
+    label: 'Focus',
+    description: 'Slight mid push to keep melodies forward while trimming rumble.',
+    bands: { low: -1, mid: 2.5, high: 1.5 },
+  },
+  {
+    id: 'sparkle',
+    label: 'Sparkle',
+    description: 'Bright top-end shimmer with restrained mids.',
+    bands: { low: 1, mid: -0.5, high: 4.5 },
+  },
+]
+
+export const getEqPresetById = (id: string): EqPreset | undefined =>
+  EQ_PRESETS.find((preset) => preset.id === id)

--- a/apps/web/src/audio/preferences.ts
+++ b/apps/web/src/audio/preferences.ts
@@ -1,0 +1,70 @@
+export interface AudioSettings {
+  music: number
+  sfx: number
+  voice: number
+  eqPreset: string
+  customEq?: {
+    low: number
+    mid: number
+    high: number
+  }
+}
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (Number.isNaN(value)) return min
+  if (value < min) return min
+  if (value > max) return max
+  return value
+}
+
+export const DEFAULT_AUDIO_SETTINGS: AudioSettings = {
+  music: 1,
+  sfx: 0.9,
+  voice: 0.8,
+  eqPreset: 'flat',
+}
+
+const STORAGE_KEY = 'the-path:audio-preferences'
+
+export const sanitizeAudioSettings = (settings: Partial<AudioSettings>): AudioSettings => {
+  const preset = typeof settings.eqPreset === 'string' ? settings.eqPreset : DEFAULT_AUDIO_SETTINGS.eqPreset
+  return {
+    music: clamp(settings.music ?? DEFAULT_AUDIO_SETTINGS.music, 0, 2),
+    sfx: clamp(settings.sfx ?? DEFAULT_AUDIO_SETTINGS.sfx, 0, 2),
+    voice: clamp(settings.voice ?? DEFAULT_AUDIO_SETTINGS.voice, 0, 2),
+    eqPreset: preset,
+    customEq: settings.customEq
+      ? {
+          low: clamp(settings.customEq.low, -12, 12),
+          mid: clamp(settings.customEq.mid, -12, 12),
+          high: clamp(settings.customEq.high, -12, 12),
+        }
+      : undefined,
+  }
+}
+
+export const readAudioSettings = (storage?: Storage): AudioSettings => {
+  const target = storage ?? (typeof window !== 'undefined' ? window.localStorage : null)
+  if (!target) return { ...DEFAULT_AUDIO_SETTINGS }
+  try {
+    const raw = target.getItem(STORAGE_KEY)
+    if (!raw) return { ...DEFAULT_AUDIO_SETTINGS }
+    const parsed = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null) {
+      return { ...DEFAULT_AUDIO_SETTINGS }
+    }
+    return sanitizeAudioSettings(parsed as Partial<AudioSettings>)
+  } catch {
+    return { ...DEFAULT_AUDIO_SETTINGS }
+  }
+}
+
+export const writeAudioSettings = (settings: AudioSettings, storage?: Storage): void => {
+  const target = storage ?? (typeof window !== 'undefined' ? window.localStorage : null)
+  if (!target) return
+  try {
+    target.setItem(STORAGE_KEY, JSON.stringify(settings))
+  } catch {
+    /* ignore persistence failures */
+  }
+}

--- a/apps/web/src/audio/proceduralSfx.ts
+++ b/apps/web/src/audio/proceduralSfx.ts
@@ -1,0 +1,223 @@
+import presetsJson from './sfxPresets.json'
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (Number.isNaN(value)) return min
+  if (value < min) return min
+  if (value > max) return max
+  return value
+}
+
+export interface BeatGridSnapshot {
+  interval: number
+}
+
+export interface SfxTriggerOptions {
+  intensity?: number
+  grid?: BeatGridSnapshot | null
+}
+
+interface RawOscillatorPreset {
+  readonly type: OscillatorType
+  readonly ratio: number
+  readonly gain: number
+  readonly detune?: number
+}
+
+interface RawNoisePreset {
+  readonly type: 'white' | 'pink'
+  readonly gain: number
+  readonly decay?: number
+}
+
+interface RawFilterPreset {
+  readonly type: BiquadFilterType
+  readonly frequency: number
+  readonly Q?: number
+}
+
+interface RawEnvelopePreset {
+  readonly attack: number
+  readonly decay: number
+  readonly sustain: number
+  readonly release: number
+}
+
+interface RawSfxPreset {
+  readonly gain: number
+  readonly envelope: RawEnvelopePreset
+  readonly oscillators?: RawOscillatorPreset[]
+  readonly noise?: RawNoisePreset
+  readonly filter?: RawFilterPreset
+  readonly pitchJitter?: number
+}
+
+const PRESETS = presetsJson as Record<string, RawSfxPreset>
+
+const toSeconds = (value: number): number => clamp(value, 0.001, 4)
+
+const quantizeFrequency = (frequency: number): number => {
+  const clamped = clamp(frequency, 20, 16000)
+  const midi = 69 + 12 * Math.log2(clamped / 440)
+  const rounded = Math.round(midi)
+  return 440 * 2 ** ((rounded - 69) / 12)
+}
+
+const pinkNoiseBuffer = (context: AudioContext): AudioBuffer => {
+  const length = Math.floor(context.sampleRate * 0.5)
+  const buffer = context.createBuffer(1, length, context.sampleRate)
+  const data = buffer.getChannelData(0)
+  let b0 = 0
+  let b1 = 0
+  let b2 = 0
+  for (let i = 0; i < length; i += 1) {
+    const white = Math.random() * 2 - 1
+    b0 = 0.997 * b0 + white * 0.0997
+    b1 = 0.985 * b1 + white * 0.1348
+    b2 = 0.950 * b2 + white * 0.1159
+    data[i] = (b0 + b1 + b2 + white * 0.5362) * 0.3
+  }
+  return buffer
+}
+
+const whiteNoiseBuffer = (context: AudioContext): AudioBuffer => {
+  const length = Math.floor(context.sampleRate * 0.4)
+  const buffer = context.createBuffer(1, length, context.sampleRate)
+  const data = buffer.getChannelData(0)
+  for (let i = 0; i < length; i += 1) {
+    const fade = 1 - i / length
+    data[i] = (Math.random() * 2 - 1) * fade
+  }
+  return buffer
+}
+
+const NOISE_CACHE = new WeakMap<AudioContext, { white: AudioBuffer; pink: AudioBuffer }>()
+
+const resolveNoiseBuffer = (context: AudioContext, type: 'white' | 'pink'): AudioBuffer => {
+  const cached = NOISE_CACHE.get(context)
+  if (cached) {
+    return cached[type]
+  }
+  const entry = {
+    white: whiteNoiseBuffer(context),
+    pink: pinkNoiseBuffer(context),
+  }
+  NOISE_CACHE.set(context, entry)
+  return entry[type]
+}
+
+export class ProceduralSfxEngine {
+  constructor(
+    private readonly context: AudioContext,
+    private readonly output: GainNode,
+    private readonly gridProvider: () => BeatGridSnapshot | null,
+  ) {}
+
+  trigger(name: string, options: SfxTriggerOptions = {}): void {
+    const preset = PRESETS[name]
+    if (!preset) return
+
+    const intensity = clamp(options.intensity ?? 1, 0.1, 2.5)
+    const now = this.context.currentTime
+
+    const envelopeGain = this.context.createGain()
+    envelopeGain.gain.value = 0
+
+    const targetNode = preset.filter ? this.createFilterChain(preset.filter, envelopeGain) : envelopeGain
+
+    if (preset.oscillators?.length) {
+      for (const oscPreset of preset.oscillators) {
+        this.createOscillatorVoice(oscPreset, preset, intensity, targetNode, options.grid)
+      }
+    }
+
+    if (preset.noise) {
+      this.createNoiseVoice(preset.noise, preset, intensity, targetNode)
+    }
+
+    const duration =
+      preset.envelope.attack + preset.envelope.decay + preset.envelope.release + Math.max(0.05, preset.envelope.sustain * 0.12)
+
+    envelopeGain.connect(this.output)
+    envelopeGain.gain.setValueAtTime(0, now)
+    envelopeGain.gain.linearRampToValueAtTime(preset.gain * intensity, now + toSeconds(preset.envelope.attack))
+    const sustainLevel = clamp(preset.envelope.sustain, 0, 1) * preset.gain * intensity
+    envelopeGain.gain.linearRampToValueAtTime(sustainLevel + 0.0001, now + toSeconds(preset.envelope.attack + preset.envelope.decay))
+    envelopeGain.gain.setTargetAtTime(0.0001, now + duration, Math.max(0.08, preset.envelope.release * 0.65))
+
+    setTimeout(() => {
+      try {
+        envelopeGain.disconnect()
+      } catch {
+        /* noop */
+      }
+    }, Math.ceil(duration * 1000) + 120)
+  }
+
+  private resolveFrequency(ratio: number, gridOverride?: BeatGridSnapshot | null): number {
+    const grid = gridOverride ?? this.gridProvider()
+    if (!grid) {
+      return quantizeFrequency(440 * ratio)
+    }
+    let base = 1 / Math.max(grid.interval, 0.001)
+    while (base < 55) base *= 2
+    while (base > 880) base /= 2
+    const fundamental = base * 4
+    const jitter = (Math.random() * 2 - 1) * 0.5
+    return quantizeFrequency((fundamental + jitter) * ratio)
+  }
+
+  private createOscillatorVoice(
+    oscPreset: RawOscillatorPreset,
+    preset: RawSfxPreset,
+    intensity: number,
+    destination: AudioNode,
+    gridOverride?: BeatGridSnapshot | null,
+  ): void {
+    const oscillator = this.context.createOscillator()
+    oscillator.type = oscPreset.type
+    oscillator.frequency.value = this.resolveFrequency(oscPreset.ratio, gridOverride)
+    if (oscPreset.detune) {
+      oscillator.detune.value = oscPreset.detune
+    }
+
+    const gain = this.context.createGain()
+    const peak = clamp(oscPreset.gain * preset.gain * intensity, 0, 2)
+    const now = this.context.currentTime
+    gain.gain.setValueAtTime(0, now)
+    gain.gain.linearRampToValueAtTime(peak, now + toSeconds(preset.envelope.attack * 0.6))
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + toSeconds(preset.envelope.attack + preset.envelope.decay + preset.envelope.release))
+
+    oscillator.connect(gain)
+    gain.connect(destination)
+    oscillator.start(now)
+    oscillator.stop(now + toSeconds(preset.envelope.attack + preset.envelope.decay + preset.envelope.release * 1.5))
+  }
+
+  private createNoiseVoice(noisePreset: RawNoisePreset, preset: RawSfxPreset, intensity: number, destination: AudioNode): void {
+    const buffer = resolveNoiseBuffer(this.context, noisePreset.type)
+    const source = this.context.createBufferSource()
+    source.buffer = buffer
+    source.playbackRate.value = noisePreset.type === 'pink' ? 1 : 2.1
+
+    const gain = this.context.createGain()
+    const now = this.context.currentTime
+    const maxGain = clamp(noisePreset.gain * preset.gain * intensity, 0, 2)
+    gain.gain.setValueAtTime(0, now)
+    gain.gain.linearRampToValueAtTime(maxGain, now + toSeconds(preset.envelope.attack * 0.4))
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + toSeconds(noisePreset.decay ?? preset.envelope.decay))
+
+    source.connect(gain)
+    gain.connect(destination)
+    source.start(now)
+    source.stop(now + toSeconds((noisePreset.decay ?? preset.envelope.decay) + preset.envelope.release))
+  }
+
+  private createFilterChain(filterPreset: RawFilterPreset, envelopeGain: GainNode): BiquadFilterNode {
+    const filter = this.context.createBiquadFilter()
+    filter.type = filterPreset.type
+    filter.frequency.value = clamp(filterPreset.frequency, 40, 16000)
+    filter.Q.value = clamp(filterPreset.Q ?? 1, 0.05, 24)
+    filter.connect(envelopeGain)
+    return filter
+  }
+}

--- a/apps/web/src/audio/recentTracks.ts
+++ b/apps/web/src/audio/recentTracks.ts
@@ -7,6 +7,7 @@ export interface StoredRecentTrack {
   duration: number
   bpm: number
   createdAt: number
+  peaks?: number[]
 }
 
 export const RECENT_TRACKS_STORAGE_KEY = 'the-path:recent-tracks'
@@ -25,6 +26,9 @@ const getStorage = (storage?: Storage): Storage | null => {
 const isFiniteNumber = (value: unknown): value is number =>
   typeof value === 'number' && Number.isFinite(value)
 
+const isValidPeaks = (value: unknown): value is number[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === 'number' && Number.isFinite(entry))
+
 const isValidRecord = (value: unknown): value is StoredRecentTrack => {
   if (typeof value !== 'object' || value === null) return false
   const record = value as Partial<StoredRecentTrack>
@@ -34,7 +38,8 @@ const isValidRecord = (value: unknown): value is StoredRecentTrack => {
     typeof record.artist === 'string' &&
     isFiniteNumber(record.duration) &&
     isFiniteNumber(record.bpm) &&
-    isFiniteNumber(record.createdAt)
+    isFiniteNumber(record.createdAt) &&
+    (record.peaks === undefined || isValidPeaks(record.peaks))
   )
 }
 
@@ -83,4 +88,5 @@ export const toManifest = (entry: StoredRecentTrack): AudioTrackManifestEntry =>
   artist: entry.artist,
   duration: entry.duration,
   bpm: entry.bpm,
+  peaks: entry.peaks,
 })

--- a/apps/web/src/audio/sfxPresets.json
+++ b/apps/web/src/audio/sfxPresets.json
@@ -1,0 +1,50 @@
+{
+  "tap": {
+    "gain": 0.9,
+    "envelope": { "attack": 0.004, "decay": 0.12, "sustain": 0, "release": 0.1 },
+    "oscillators": [
+      { "type": "sine", "ratio": 2.0, "gain": 0.65 },
+      { "type": "triangle", "ratio": 3.01, "gain": 0.25, "detune": -8 }
+    ],
+    "noise": { "type": "white", "gain": 0.35, "decay": 0.12 },
+    "filter": { "type": "bandpass", "frequency": 2100, "Q": 1.2 }
+  },
+  "perfect": {
+    "gain": 1.1,
+    "envelope": { "attack": 0.002, "decay": 0.22, "sustain": 0.35, "release": 0.32 },
+    "oscillators": [
+      { "type": "sawtooth", "ratio": 4, "gain": 0.4 },
+      { "type": "square", "ratio": 8, "gain": 0.25 }
+    ],
+    "noise": { "type": "pink", "gain": 0.22, "decay": 0.28 },
+    "filter": { "type": "lowpass", "frequency": 3600, "Q": 0.9 }
+  },
+  "miss": {
+    "gain": 0.8,
+    "envelope": { "attack": 0.006, "decay": 0.18, "sustain": 0, "release": 0.4 },
+    "oscillators": [
+      { "type": "triangle", "ratio": 0.5, "gain": 0.5 }
+    ],
+    "noise": { "type": "pink", "gain": 0.4, "decay": 0.4 },
+    "filter": { "type": "lowpass", "frequency": 1200, "Q": 1.8 }
+  },
+  "fever-start": {
+    "gain": 1.2,
+    "envelope": { "attack": 0.01, "decay": 0.4, "sustain": 0.5, "release": 0.6 },
+    "oscillators": [
+      { "type": "sawtooth", "ratio": 2, "gain": 0.45 },
+      { "type": "sine", "ratio": 1, "gain": 0.25 }
+    ],
+    "noise": { "type": "white", "gain": 0.18, "decay": 0.3 },
+    "filter": { "type": "bandpass", "frequency": 1600, "Q": 0.7 }
+  },
+  "lane-shift": {
+    "gain": 0.6,
+    "envelope": { "attack": 0.003, "decay": 0.18, "sustain": 0, "release": 0.14 },
+    "oscillators": [
+      { "type": "square", "ratio": 1.5, "gain": 0.4 },
+      { "type": "triangle", "ratio": 0.75, "gain": 0.22 }
+    ],
+    "filter": { "type": "bandpass", "frequency": 900, "Q": 2 }
+  }
+}

--- a/apps/web/src/screens/Settings.tsx
+++ b/apps/web/src/screens/Settings.tsx
@@ -1,5 +1,9 @@
+import { useEffect, useRef, useState } from 'react'
 import type { CalibrationSettings } from '../world'
 import { CALIBRATION_LIMIT_MS } from '../world/constants'
+import type { AudioSettings } from '../audio/preferences'
+import type { EqPreset } from '../audio/eqPresets'
+import type { WebAudioAnalysis } from '../audio/WebAudioAnalysis'
 
 interface SettingsScreenProps {
   dprCap: number
@@ -8,10 +12,152 @@ interface SettingsScreenProps {
   onChangeReducedMotion: (value: boolean) => void
   calibration: CalibrationSettings
   onChangeCalibration: (value: CalibrationSettings) => void
+  audio: WebAudioAnalysis
+  audioSettings: AudioSettings
+  onChangeAudioSettings: (value: AudioSettings) => void
+  eqPresets: EqPreset[]
   onBack: () => void
 }
 
 const DPR_OPTIONS = [1, 1.5, 2]
+
+const BEAT_PERIOD_MS = 1200
+
+interface CalibrationPadProps {
+  audio: WebAudioAnalysis
+  offset: number
+  onApply: (offset: number) => void
+}
+
+const mod = (value: number, base: number): number => ((value % base) + base) % base
+
+const CalibrationPad = ({ audio, offset, onApply }: CalibrationPadProps) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const [pending, setPending] = useState(offset)
+  const rafRef = useRef<number>(0)
+  const lastAudioPhase = useRef(0)
+  const startTimeRef = useRef<number | null>(null)
+  const timeoutRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    setPending(offset)
+  }, [offset])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return undefined
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return undefined
+
+    const render = (timestamp: number) => {
+      if (startTimeRef.current === null) {
+        startTimeRef.current = timestamp
+      }
+      const elapsed = timestamp - startTimeRef.current
+      const phase = mod(elapsed, BEAT_PERIOD_MS) / BEAT_PERIOD_MS
+      const offsetPhase = mod(phase + pending / BEAT_PERIOD_MS, 1)
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      ctx.fillStyle = 'rgba(12, 19, 28, 0.85)'
+      ctx.fillRect(0, 0, canvas.width, canvas.height)
+
+      const radius = Math.min(canvas.width, canvas.height) * 0.35
+      const centerX = canvas.width / 2
+      const centerY = canvas.height / 2
+
+      ctx.strokeStyle = 'rgba(56, 189, 248, 0.35)'
+      ctx.lineWidth = 2
+      ctx.beginPath()
+      ctx.arc(centerX, centerY, radius, 0, Math.PI * 2)
+      ctx.stroke()
+
+      const drawMarker = (angle: number, color: string) => {
+        const x = centerX + Math.cos(angle) * radius
+        const y = centerY + Math.sin(angle) * radius
+        ctx.fillStyle = color
+        ctx.beginPath()
+        ctx.arc(x, y, 8, 0, Math.PI * 2)
+        ctx.fill()
+      }
+
+      drawMarker(phase * Math.PI * 2 - Math.PI / 2, 'rgba(59, 130, 246, 0.85)')
+      drawMarker(offsetPhase * Math.PI * 2 - Math.PI / 2, 'rgba(248, 113, 113, 0.8)')
+
+      if (offsetPhase < lastAudioPhase.current) {
+        if (timeoutRef.current !== null) {
+          window.clearTimeout(timeoutRef.current)
+        }
+        const delay = Math.max(0, pending)
+        timeoutRef.current = window.setTimeout(() => {
+          audio.playSfx('tap', { intensity: 0.7 })
+        }, delay)
+        if (pending <= 0) {
+          audio.playSfx('tap', { intensity: 0.7 })
+        }
+      }
+      lastAudioPhase.current = offsetPhase
+
+      rafRef.current = requestAnimationFrame(render)
+    }
+
+    rafRef.current = requestAnimationFrame(render)
+
+    return () => {
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = 0
+      }
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current)
+        timeoutRef.current = null
+      }
+      startTimeRef.current = null
+      lastAudioPhase.current = 0
+    }
+  }, [audio, pending])
+
+  return (
+    <div className="space-y-3">
+      <div className="relative mx-auto flex h-40 w-full max-w-xs items-center justify-center overflow-hidden rounded-3xl border border-slate-700/60 bg-slate-900/60">
+        <canvas ref={canvasRef} width={240} height={160} className="absolute inset-0 h-full w-full" />
+        <div className="relative z-10 text-center text-xs text-slate-300">
+          <p>Синяя метка — визуал, красная — звук.</p>
+          <p>Подберите смещение, чтобы слышимое совпало с визуалом.</p>
+        </div>
+      </div>
+      <label className="flex flex-col gap-2 text-xs text-slate-300">
+        <span>
+          Смещение аудио: <span className="font-mono text-slate-200">{pending.toFixed(0)} мс</span>
+        </span>
+        <input
+          type="range"
+          min={-200}
+          max={200}
+          step={1}
+          value={pending}
+          onChange={(event) => setPending(Number(event.target.value))}
+          className="accent-cyan-400"
+        />
+      </label>
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={() => setPending(0)}
+          className="rounded-full border border-slate-700/60 px-3 py-1 text-xs text-slate-200 transition hover:border-cyan-400/50"
+        >
+          Сбросить
+        </button>
+        <button
+          type="button"
+          onClick={() => onApply(Math.round(pending))}
+          className="ml-auto rounded-full bg-cyan-500/80 px-4 py-1 text-xs font-semibold text-slate-950 shadow"
+        >
+          Сохранить смещение
+        </button>
+      </div>
+    </div>
+  )
+}
 
 export function SettingsScreen({
   dprCap,
@@ -20,11 +166,38 @@ export function SettingsScreen({
   onChangeReducedMotion,
   calibration,
   onChangeCalibration,
+  audio,
+  audioSettings,
+  onChangeAudioSettings,
+  eqPresets,
   onBack,
 }: SettingsScreenProps) {
   const handleCalibrationChange = (key: keyof CalibrationSettings, value: number) => {
     const clamped = Math.max(-CALIBRATION_LIMIT_MS, Math.min(CALIBRATION_LIMIT_MS, Math.round(value)))
     onChangeCalibration({ ...calibration, [key]: clamped })
+  }
+
+  const handleVolumeChange = (key: keyof Pick<AudioSettings, 'music' | 'sfx' | 'voice'>, value: number) => {
+    const next = { ...audioSettings, [key]: Math.round(value * 100) / 100 }
+    onChangeAudioSettings(next)
+  }
+
+  const handleEqPresetChange = (presetId: string) => {
+    if (presetId === 'custom') {
+      const current = audioSettings.customEq ?? { low: 0, mid: 0, high: 0 }
+      onChangeAudioSettings({ ...audioSettings, eqPreset: 'custom', customEq: current })
+      return
+    }
+    onChangeAudioSettings({ ...audioSettings, eqPreset: presetId, customEq: undefined })
+  }
+
+  const handleCustomEqChange = (band: 'low' | 'mid' | 'high', value: number) => {
+    const custom = audioSettings.customEq ?? { low: 0, mid: 0, high: 0 }
+    onChangeAudioSettings({
+      ...audioSettings,
+      eqPreset: 'custom',
+      customEq: { ...custom, [band]: value },
+    })
   }
 
   return (
@@ -83,8 +256,100 @@ export function SettingsScreen({
         </section>
 
         <section className="space-y-4 rounded-3xl border border-slate-700/60 bg-slate-900/80 p-6">
+          <h2 className="text-sm font-semibold text-white">Громкость</h2>
+          <p className="text-xs text-slate-400">Раздельные уровни для музыки, эффектов и голосовых подсказок.</p>
+          <div className="space-y-4">
+            {[
+              { key: 'music', label: 'Музыка', value: audioSettings.music },
+              { key: 'sfx', label: 'SFX', value: audioSettings.sfx },
+              { key: 'voice', label: 'Голоса', value: audioSettings.voice },
+            ].map((entry) => (
+              <label key={entry.key} className="flex flex-col gap-2 text-xs text-slate-300">
+                <span>
+                  {entry.label}{' '}
+                  <span className="font-mono text-slate-200">{Math.round(entry.value * 100)}%</span>
+                </span>
+                <input
+                  type="range"
+                  min={0}
+                  max={2}
+                  step={0.01}
+                  value={entry.value}
+                  onChange={(event) => handleVolumeChange(entry.key as 'music' | 'sfx' | 'voice', Number(event.target.value))}
+                  className="accent-cyan-400"
+                />
+              </label>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-4 rounded-3xl border border-slate-700/60 bg-slate-900/80 p-6">
+          <h2 className="text-sm font-semibold text-white">Эквалайзер</h2>
+          <p className="text-xs text-slate-400">Выберите готовый пресет или настройте вручную.</p>
+          <div className="space-y-3">
+            <div className="flex flex-wrap gap-2">
+              {eqPresets.map((preset) => (
+                <button
+                  key={preset.id}
+                  type="button"
+                  onClick={() => handleEqPresetChange(preset.id)}
+                  className={`rounded-full px-3 py-1 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
+                    audioSettings.eqPreset === preset.id
+                      ? 'bg-gradient-to-r from-cyan-400 to-sky-500 text-slate-950 shadow'
+                      : 'border border-slate-700/60 bg-slate-900/70 text-slate-200 hover:border-cyan-400/50'
+                  }`}
+                >
+                  {preset.label}
+                </button>
+              ))}
+              <button
+                type="button"
+                onClick={() => handleEqPresetChange('custom')}
+                className={`rounded-full px-3 py-1 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
+                  audioSettings.eqPreset === 'custom'
+                    ? 'bg-gradient-to-r from-cyan-400 to-sky-500 text-slate-950 shadow'
+                    : 'border border-slate-700/60 bg-slate-900/70 text-slate-200 hover:border-cyan-400/50'
+                }`}
+              >
+                Custom
+              </button>
+            </div>
+            {audioSettings.eqPreset === 'custom' ? (
+              <div className="grid gap-3 md:grid-cols-3">
+                {[
+                  { key: 'low', label: 'Низ' },
+                  { key: 'mid', label: 'Середина' },
+                  { key: 'high', label: 'Верх' },
+                ].map((band) => (
+                  <label key={band.key} className="flex flex-col gap-2 text-xs text-slate-300">
+                    <span>
+                      {band.label} {audioSettings.customEq ? Math.round(audioSettings.customEq[band.key as 'low' | 'mid' | 'high'] * 10) / 10 : 0} дБ
+                    </span>
+                    <input
+                      type="range"
+                      min={-12}
+                      max={12}
+                      step={0.5}
+                      value={audioSettings.customEq ? audioSettings.customEq[band.key as 'low' | 'mid' | 'high'] : 0}
+                      onChange={(event) => handleCustomEqChange(band.key as 'low' | 'mid' | 'high', Number(event.target.value))}
+                      className="accent-cyan-400"
+                    />
+                  </label>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </section>
+
+        <section className="space-y-4 rounded-3xl border border-slate-700/60 bg-slate-900/80 p-6">
           <h2 className="text-sm font-semibold text-white">Калибровка</h2>
-          <p className="text-xs text-slate-400">Сдвиг входа и аудио (±{CALIBRATION_LIMIT_MS} мс) для компенсации задержки устройства.</p>
+          <p className="text-xs text-slate-400">Подберите смещение, чтобы визуальный и аудио-ритм совпали.</p>
+          <CalibrationPad
+            audio={audio}
+            offset={calibration.audioOffsetMs}
+            onApply={(offsetMs) => handleCalibrationChange('audioOffsetMs', offsetMs)}
+          />
+          <p className="text-xs text-slate-400">Точные значения можно указать вручную (±{CALIBRATION_LIMIT_MS} мс).</p>
           <div className="grid gap-4 sm:grid-cols-2">
             <label className="flex flex-col gap-2 text-xs text-slate-300">
               <span>Input offset</span>

--- a/apps/web/src/ui/BeatDebugOverlay.tsx
+++ b/apps/web/src/ui/BeatDebugOverlay.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useRef } from 'react'
+import type { WebAudioAnalysis, BeatEvent, OnsetEvent, BeatGridState } from '../audio/WebAudioAnalysis'
+
+interface BeatDebugOverlayProps {
+  audio: WebAudioAnalysis
+  canvasRef: React.RefObject<HTMLCanvasElement>
+}
+
+const MAX_HISTORY = 64
+const WINDOW_SECONDS = 4
+
+const clamp01 = (value: number): number => {
+  if (value <= 0) return 0
+  if (value >= 1) return 1
+  return value
+}
+
+export function BeatDebugOverlay({ audio, canvasRef }: BeatDebugOverlayProps) {
+  const overlayRef = useRef<HTMLCanvasElement | null>(null)
+  const beatsRef = useRef<BeatEvent[]>([])
+  const onsetsRef = useRef<OnsetEvent[]>([])
+  const gridRef = useRef<BeatGridState | null>(null)
+  const rafRef = useRef<number>(0)
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return undefined
+    const overlay = overlayRef.current
+    const baseCanvas = canvasRef.current
+    if (!overlay || !baseCanvas) return undefined
+
+    const resize = () => {
+      const rect = baseCanvas.getBoundingClientRect()
+      overlay.width = rect.width
+      overlay.height = rect.height
+    }
+
+    resize()
+
+    const observer = new ResizeObserver(() => resize())
+    observer.observe(baseCanvas)
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [canvasRef])
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return undefined
+    const detachBeat = audio.onBeat((event) => {
+      beatsRef.current.push(event)
+      if (beatsRef.current.length > MAX_HISTORY) {
+        beatsRef.current.shift()
+      }
+    })
+    const detachOnset = audio.onOnset((event) => {
+      onsetsRef.current.push(event)
+      if (onsetsRef.current.length > MAX_HISTORY) {
+        onsetsRef.current.shift()
+      }
+    })
+    const detachGrid = audio.onGrid((grid) => {
+      gridRef.current = grid
+    })
+
+    return () => {
+      detachBeat()
+      detachOnset()
+      detachGrid()
+    }
+  }, [audio])
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return undefined
+    const overlay = overlayRef.current
+    if (!overlay) return undefined
+    const ctx = overlay.getContext('2d')
+    if (!ctx) return undefined
+
+    const render = () => {
+      const width = overlay.width
+      const height = overlay.height
+      ctx.clearRect(0, 0, width, height)
+      ctx.fillStyle = 'rgba(12, 18, 30, 0.45)'
+      ctx.fillRect(0, 0, width, height)
+
+      const currentTime = audio.getCurrentTime()
+      const startTime = currentTime - WINDOW_SECONDS
+
+      ctx.strokeStyle = 'rgba(56, 189, 248, 0.45)'
+      ctx.lineWidth = 2
+      ctx.beginPath()
+      ctx.moveTo(0, height * 0.5)
+      ctx.lineTo(width, height * 0.5)
+      ctx.stroke()
+
+      const grid = gridRef.current
+      if (grid) {
+        const interval = grid.interval
+        const first = Math.floor(startTime / interval)
+        const last = Math.ceil(currentTime / interval)
+        ctx.strokeStyle = 'rgba(14, 165, 233, 0.35)'
+        ctx.lineWidth = 1
+        for (let i = first; i <= last; i += 1) {
+          const beatTime = i * interval
+          if (beatTime < startTime) continue
+          const ratio = 1 - (currentTime - beatTime) / WINDOW_SECONDS
+          const x = width * clamp01(ratio)
+          ctx.beginPath()
+          ctx.moveTo(x, 0)
+          ctx.lineTo(x, height)
+          ctx.stroke()
+        }
+      }
+
+      const beats = beatsRef.current.filter((event) => event.time >= startTime)
+      ctx.fillStyle = 'rgba(59, 130, 246, 0.85)'
+      for (const beat of beats) {
+        const ratio = 1 - (currentTime - beat.time) / WINDOW_SECONDS
+        const x = width * clamp01(ratio)
+        const radius = 6 + clamp01(beat.confidence / 3) * 10
+        ctx.beginPath()
+        ctx.arc(x, height * 0.35, radius, 0, Math.PI * 2)
+        ctx.fill()
+      }
+
+      const onsets = onsetsRef.current.filter((event) => event.time >= startTime)
+      ctx.fillStyle = 'rgba(248, 113, 113, 0.7)'
+      for (const onset of onsets) {
+        const ratio = 1 - (currentTime - onset.time) / WINDOW_SECONDS
+        const x = width * clamp01(ratio)
+        const heightScale = clamp01(onset.strength / 3)
+        ctx.fillRect(x - 2, height * (0.75 - heightScale * 0.25), 4, height * 0.25 * heightScale)
+      }
+
+      rafRef.current = requestAnimationFrame(render)
+    }
+
+    rafRef.current = requestAnimationFrame(render)
+
+    return () => {
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = 0
+      }
+    }
+  }, [audio])
+
+  if (!import.meta.env.DEV) {
+    return null
+  }
+
+  return (
+    <canvas
+      ref={overlayRef}
+      className="pointer-events-none absolute inset-0 z-30 mix-blend-screen"
+      aria-hidden="true"
+    />
+  )
+}
+
+export default BeatDebugOverlay

--- a/apps/web/src/world/types.ts
+++ b/apps/web/src/world/types.ts
@@ -136,3 +136,9 @@ export interface WorldSnapshot {
   }
   meta: MetaProgressState
 }
+
+export type WorldAudioEvent =
+  | { type: 'hit'; judgement: Judgement; lane: LaneIndex; time: number; combo: number }
+  | { type: 'miss'; lane: LaneIndex; time: number }
+  | { type: 'fever'; state: 'start' | 'end'; time: number }
+  | { type: 'lane-shift'; direction: 'left' | 'right'; lane: LaneIndex; time: number }


### PR DESCRIPTION
## Summary
- Overhauled the WebAudioAnalysis module with beat grid quantization, dynamic buses, procedural SFX, and support for importing user track peaks.
- Added reusable audio assets (EQ presets, audio preference storage, procedural SFX presets) and exposed calibration/EQ controls plus a developer beat debug overlay.
- Connected world audio events to procedural playback, quantized note spawning, and ducking/fever behavior.

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d5d89969a88323b2e414f95bbe83b9